### PR TITLE
Some fixes

### DIFF
--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -615,6 +615,9 @@ SDL_SetKeymap(int start, SDL_Keycode * keys, int length)
 void
 SDL_SetScancodeName(SDL_Scancode scancode, const char *name)
 {
+	if (scancode >= SDL_NUM:SCANCODES) {
+		return;
+	}
     SDL_scancode_names[scancode] = name;
 }
 
@@ -685,7 +688,7 @@ SDL_SendKeyboardKey(Uint8 state, SDL_Scancode scancode)
     Uint32 type;
     Uint8 repeat;
 
-    if (!scancode) {
+    if (!scancode || scancode >= SDL_NUM_SCANCODES) {
         return 0;
     }
 #ifdef DEBUG_KEYBOARD

--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -615,7 +615,7 @@ SDL_SetKeymap(int start, SDL_Keycode * keys, int length)
 void
 SDL_SetScancodeName(SDL_Scancode scancode, const char *name)
 {
-	if (scancode >= SDL_NUM:SCANCODES) {
+	if (scancode >= SDL_NUM_SCANCODES) {
 		return;
 	}
     SDL_scancode_names[scancode] = name;

--- a/src/video/os2/SDL_os2video.c
+++ b/src/video/os2/SDL_os2video.c
@@ -1682,8 +1682,14 @@ static int OS2_GetDisplayDPI(_THIS, SDL_VideoDisplay *display, float *ddpi,
 
 static void OS2_GetDisplayModes(_THIS, SDL_VideoDisplay *display)
 {
+  SDL_DisplayMode *mode;
+	
   debug(SDL_LOG_CATEGORY_VIDEO, "Enter" );
-  SDL_AddDisplayMode( display, &display->current_mode );
+  mode = SDL_malloc( sizeof(SDL_DisplayMode) );
+  SDL_memcpy( mode, &display->current_mode, sizeof(SDL_DisplayMode) );
+  mode->driverdata = SDL_malloc( sizeof(MODEDATA) );
+  SDL_memcpy( mode->driverdata, display->current_mode.driverdata, sizeof(MODEDATA) );
+  SDL_AddDisplayMode( display, mode );
 }
 
 static int OS2_SetDisplayMode(_THIS, SDL_VideoDisplay *display,


### PR DESCRIPTION
While porting PrBoom+ I ran into two problems:
- On a T420 pressing the ACPI button for volume control, big scancodes were emitted. This was causing an overflow, because missing guards.
- On requesting the mode list, the current mode aka desktop mode is directly added to the mode list. When exiting the application, SQL_Quit will then crash, because the video cleanup code releases the mode list data, then desktop mode data, which is at that time is already freed. My fix copies current mode data into its own data structure and adds this to the mode list.