### PR TITLE
Applied fix for relative mouse movement

### DIFF
--- a/src/video/os2/SDL_os2mouse.c
+++ b/src/video/os2/SDL_os2mouse.c
@@ -126,6 +126,8 @@ static void OS2_WarpMouse(SDL_Window * window, int x, int y)
     WinMapWindowPoints(pWinData->hwnd, HWND_DESKTOP, &pointl, 1);
 /*  pWinData->lSkipWMMouseMove++; ???*/
     WinSetPointerPos(HWND_DESKTOP, pointl.x, pointl.y);
+    
+    SDL_SendMouseMotion(window, SDL_GetMouse()->mouseID, 0, x, y);
 }
 
 static int OS2_WarpMouseGlobal(int x, int y)

--- a/src/video/os2/SDL_os2video.c
+++ b/src/video/os2/SDL_os2video.c
@@ -258,7 +258,7 @@ static VOID _wmMouseMove(WINDATA *pWinData, SHORT lX, SHORT lY)
         }
 
         SDL_SendMouseMotion(pWinData->window, 0, 0, lX,
-                            pWinData->window->h - lY - 1);
+                            pWinData->window->h - lY);
         return;
     }
 


### PR DESCRIPTION
The proposed fix for issue #5 was applied.
Also removed the `-1` in SDL_os2video.c in function OS2_WarpMouse, due to relative mouse offset of -1 even when not moving the mouse.